### PR TITLE
convert tests from tap to lab

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "tap ./test"
+    "test": "lab -v"
   },
   "repository": {
     "type": "git",
@@ -26,9 +26,9 @@
     "stream-exhaust": "^1.0.0"
   },
   "devDependencies": {
-    "tap": "~0.4.8",
     "through2": "~0.4.1",
     "when": "~2.8.0",
-    "rx": "~2.x.x"
+    "rx": "~2.x.x",
+    "lab": "^3.1.1"
   }
 }

--- a/test/callbacks.js
+++ b/test/callbacks.js
@@ -1,62 +1,65 @@
 'use strict';
 
-var test = require('tap').test;
+var lab = require('lab');
+var describe = lab.experiment;
+var it = lab.test;
+var expect = lab.expect;
 
 var asyncDone = require('../');
 
-function success(cb){
+function success(cb) {
   cb(null, 2);
 }
 
-function failure(cb){
+function failure(cb) {
   cb(new Error('Callback Error'));
 }
 
-function neverDone(someArg){
+function neverDone(someArg) {
   return 2;
 }
 
-test('handle a successful callback', function(t){
-  asyncDone(success, function(err, result){
-    t.ok(err == null, 'error should be null or undefined');
-    t.equal(result, 2, 'result should be 2');
-    t.end();
-  });
-});
+describe('callbacks', function () {
 
-test('handle an errored callback', function(t){
-  asyncDone(failure, function(err){
-    t.ok(err instanceof Error, 'error should be instance of Error');
-    t.end();
-  });
-});
-
-test('a function that takes an argument but never calls callback', function(t){
-  asyncDone(neverDone, function(err){
-    t.plan(0);
-    t.notOk(err);
-  });
-
-  setTimeout(function(){
-    t.ok(true, 'done callback never called');
-    t.end();
-  }, 1000);
-});
-
-test('should not handle error if something throws inside the callback', function(t){
-  // because tap timeout is a pain
-  setTimeout(t.timeout.bind(t), 2000);
-
-  t.plan(1);
-
-  var d = require('domain').create();
-  d.on('error', function(err){
-    t.ok(err instanceof Error, 'error is not lost');
-  });
-
-  d.run(function(){
-    asyncDone(success, function(){
-      throw new Error('Thrown Error');
+  it('should handle a successful callback', function (done) {
+    asyncDone(success, function (err, result) {
+      expect(result).to.equal(2);
+      done(err);
     });
   });
+
+  it('should handle an errored callback', function (done) {
+    asyncDone(failure, function (err, result) {
+      expect(err).to.be.instanceof(Error);
+      done();
+    });
+  });
+
+  /*it('a function that takes an argument but never calls callback', function () {
+   asyncDone(neverDone, function(err){
+   t.plan(0);
+   t.notOk(err);
+   });
+
+   setTimeout(function(){
+   t.ok(true, 'done callback never called');
+   t.end();
+   }, 1000);
+   });*/
+
+  it('should not handle error if something throws inside the callback', function (done) {
+
+    var d = require('domain').create();
+    d.on('error', function (err) {
+      expect(err).to.be.instanceof(Error);
+      done();
+    });
+
+    d.run(function () {
+      asyncDone(success, function () {
+        throw new Error('Thrown Error');
+      });
+    });
+  });
+
 });

--- a/test/observables.js
+++ b/test/observables.js
@@ -1,6 +1,9 @@
 'use strict';
 
-var test = require('tap').test;
+var lab = require('lab');
+var describe = lab.experiment;
+var it = lab.test;
+var expect = lab.expect;
 
 var asyncDone = require('../');
 
@@ -18,31 +21,31 @@ function failure() {
   return Observable.throw(new Error('Observable error'));
 }
 
-test('handle a finished observable', function(t){
-  asyncDone(success, function(err, result){
-    t.ok(err == null, 'error should be null or undefined');
-    t.equal(result, undefined, 'result should be undefined');
-    t.end();
+describe('observables', function () {
+
+  it('should handle a finished observable', function (done) {
+    asyncDone(success, function (err, result) {
+      expect(result).to.be.undefined;
+      done(err);
+    });
   });
-});
 
-/*
-
-Currently, we don't support values returned from observables.
-This keeps the code simpler.
-
-test('handle a finished observable with value', function(t){
-  asyncDone(successValue, function(err, result){
-    t.ok(err == null, 'error should be null or undefined');
-    t.equal(result, 42, 'result should be 42');
-    t.end();
+  /*
+   Currently, we don't support values returned from observables.
+   This keeps the code simpler.
+  it('should handle a finished observable with value', function (done) {
+    asyncDone(successValue, function (err, result) {
+      expect(result).to.equal(42);
+      done(err);
+    });
   });
-});
- */
+   */
 
-test('handle an errored observable', function(t){
-  asyncDone(failure, function(err){
-    t.ok(err instanceof Error, 'error should be instance of Error');
-    t.end();
+  it('should handle an errored observable', function (done) {
+    asyncDone(failure, function (err) {
+      expect(err).to.be.instanceof(Error);
+      done();
+    });
   });
+
 });

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,29 +1,36 @@
 'use strict';
 
-var test = require('tap').test;
+var lab = require('lab');
+var describe = lab.experiment;
+var it = lab.test;
+var expect = lab.expect;
+
 var when = require('when');
 
 var asyncDone = require('../');
 
-function success(){
+function success() {
   return when.resolve(2);
 }
 
-function failure(){
+function failure() {
   return when.reject(new Error('Promise Error'));
 }
 
-test('handle a resolved promise', function(t){
-  asyncDone(success, function(err, result){
-    t.ok(err == null, 'error should be null or undefined');
-    t.equal(result, 2, 'result should be 2');
-    t.end();
-  });
-});
+describe('promises', function () {
 
-test('handle a rejected promise', function(t){
-  asyncDone(failure, function(err){
-    t.ok(err instanceof Error, 'error should be instance of Error');
-    t.end();
+  it('should handle a resolved promise', function (done) {
+    asyncDone(success, function (err, result) {
+      expect(result).to.equal(2);
+      done(err);
+    });
   });
+
+  it('should handle a rejected promise', function (done) {
+    asyncDone(failure, function (err, result) {
+      expect(err).to.be.instanceof(Error);
+      done();
+    });
+  });
+
 });

--- a/test/streams.js
+++ b/test/streams.js
@@ -1,9 +1,12 @@
 'use strict';
 
+var lab = require('lab');
+var describe = lab.experiment;
+var it = lab.test;
+var expect = lab.expect;
+
 var fs = require('fs');
 var path = require('path');
-
-var test = require('tap').test;
 var through = require('through2');
 
 var asyncDone = require('../');
@@ -11,55 +14,57 @@ var asyncDone = require('../');
 var exists = path.join(__dirname, '../.gitignore');
 var notExists = path.join(__dirname, '../not_exists');
 
-var EndStream = through.ctor(function(chunk, enc, cb){
+var EndStream = through.ctor(function (chunk, enc, cb) {
   this.push(chunk);
   cb();
-}, function(cb){
+}, function (cb) {
   this.emit('end', 2);
   cb();
 });
 
-function success(){
+function success() {
   var read = fs.createReadStream(exists);
   return read.pipe(new EndStream());
 }
 
-function failure(){
+function failure() {
   var read = fs.createReadStream(notExists);
   return read.pipe(new EndStream());
 }
 
-function unpiped(){
+function unpiped() {
   return fs.createReadStream(exists);
 }
 
-test('handle a successful stream', function(t){
-  asyncDone(success, function(err){
-    t.ok(err == null, 'error should be null or undefined');
-    t.end();
-  });
-});
+describe('streams', function () {
 
-test('handle an errored stream', function(t){
-  asyncDone(failure, function(err){
-    t.ok(err instanceof Error, 'error should be instance of Error');
-    t.ok(err.domainEmitter, 'error should be caught by domain');
-    t.end();
+  it('should handle a successful stream', function (done) {
+    asyncDone(success, function (err) {
+      expect(err).to.not.exist;
+      done();
+    });
   });
-});
 
-test('handle a returned stream and cb by only calling callback once', function(t){
-  asyncDone(function(cb){
-    return success().on('end', function(){ cb(); });
-  }, function(err){
-    t.ok(err == null, 'error should be null or undefined');
-    t.end();
+  it('should handle an errored stream', function (done) {
+    asyncDone(failure, function(err){
+      expect(err).to.be.instanceof(Error);
+      done();
+    });
   });
-});
 
-test('consumes an unpiped readable stream', function(t){
-  asyncDone(unpiped, function(err){
-    t.ok(err == null, 'error should be null or undefined');
-    t.end();
+  it('handle a returned stream and cb by only calling callback once', function(done){
+    asyncDone(function(cb){
+      return success().on('end', function(){ cb(); });
+    }, function(err){
+      expect(err).to.not.exist;
+      done();
+    });
+  });
+
+  it('consumes an unpiped readable stream', function (done) {
+    asyncDone(unpiped, function(err){
+      expect(err).to.not.exist;
+      done();
+    });
   });
 });


### PR DESCRIPTION
@phated I'm not big fan of tap's syntax (to put it mildly) so was happy to see that you've proposed moving to lab/chai. I've took a stab at converting tests from tap => lab as since it proved to be a pretty easy exercise, here is the PR.

The only test I didn't convert is [this one](https://github.com/phated/async-done/blob/31d148890a686a69f93d13b208ebe0c9d6f58c04/test/callbacks.js#L34-L44) as I wasn't quite sure what it is trying to verify :-/ Happy to amend the PR if you could provide some guidance. 

Closes #12 
